### PR TITLE
fix: Add tests for NumPy input validation in plot_heatmap

### DIFF
--- a/src/dsci_524_ezplot/plot_heatmap.py
+++ b/src/dsci_524_ezplot/plot_heatmap.py
@@ -3,17 +3,17 @@ import seaborn as sns
 import pandas as pd
 import numpy as np
 
-def plot_heatmap(df, title=None, cmap="viridis", xlabel=None, ylabel=None):
+def plot_heatmap(data, title=None, cmap="viridis", xlabel=None, ylabel=None):
     """
-    Create a heatmap using data from a pandas DataFrame or a 2D array.
+    Create a heatmap using a pandas DataFrame or a 2D NumPy array.
 
     Parameters
     ----------
-    df : pandas.DataFrame or numpy.ndarray
+    data : pandas.DataFrame or numpy.ndarray
         Input data for the heatmap. Can be a pandas DataFrame or a 2D NumPy array.
-        The data should be numeric, as non-numeric values will cause errors.
-    title : str
-        Title of the heatmap.
+        The data should be numeric; non-numeric values will cause errors.
+    title : str, optional
+        Title of the heatmap. Default is None.
     cmap : str, optional
         Colormap for the heatmap. Defaults to 'viridis'.
     xlabel : str, optional
@@ -32,42 +32,47 @@ def plot_heatmap(df, title=None, cmap="viridis", xlabel=None, ylabel=None):
     Raises
     ------
     TypeError
-        If the input data contains non-numeric values.
+        If the input data is not a pandas DataFrame or a NumPy array.
     ValueError
-        If the input data is empty.
+        If the input data is empty or contains non-numeric values.
 
     Examples
     --------
+    Using a pandas DataFrame:
     >>> import pandas as pd
     >>> import numpy as np
     >>> df = pd.DataFrame(np.random.rand(5, 5), columns=['A', 'B', 'C', 'D', 'E'])
     >>> fig, ax = plot_heatmap(df, title="Sample Heatmap", xlabel="Columns", ylabel="Rows")
+
+    Using a NumPy array:
+    >>> arr = np.random.rand(5, 5)
+    >>> fig, ax = plot_heatmap(arr, title="Heatmap from NumPy array")
     """
     # Validate input type
-    if not isinstance(df, (pd.DataFrame, np.ndarray)):
-        raise TypeError("Input data must be a pandas DataFrame or a numpy array.")
+    if not isinstance(data, (pd.DataFrame, np.ndarray)):
+        raise TypeError("Input data must be a pandas DataFrame or a NumPy array.")
     
     # Handle empty data
-    if isinstance(df, pd.DataFrame) and df.empty:
+    if isinstance(data, pd.DataFrame) and data.empty:
         raise ValueError("DataFrame must not be empty.")
-    if isinstance(df, np.ndarray) and df.size == 0:
+    if isinstance(data, np.ndarray) and data.size == 0:
         raise ValueError("NumPy array must not be empty.")
     
     # Ensure data is numeric
-    if isinstance(df, pd.DataFrame):
-        if not all(pd.api.types.is_numeric_dtype(dtype) for dtype in df.dtypes):
+    if isinstance(data, pd.DataFrame):
+        if not all(pd.api.types.is_numeric_dtype(dtype) for dtype in data.dtypes):
             raise TypeError("All columns in the DataFrame must contain numeric data.")
-    elif isinstance(df, np.ndarray):
-        if not np.issubdtype(df.dtype, np.number):
+    elif isinstance(data, np.ndarray):
+        if not np.issubdtype(data.dtype, np.number):
             raise TypeError("NumPy array must contain numeric data.")
     
     # Handle NaN values
-    if isinstance(df, pd.DataFrame) and df.isnull().values.any():
-        df = df.fillna(0)
+    if isinstance(data, pd.DataFrame) and data.isnull().values.any():
+        data = data.fillna(0)
 
     # Plot the heatmap
     fig, ax = plt.subplots()
-    sns.heatmap(df, cmap=cmap, ax=ax)
+    sns.heatmap(data, cmap=cmap, ax=ax)
     ax.set_title(title)
     if xlabel:
         ax.set_xlabel(xlabel)

--- a/src/dsci_524_ezplot/plot_heatmap.py
+++ b/src/dsci_524_ezplot/plot_heatmap.py
@@ -50,7 +50,7 @@ def plot_heatmap(data, title=None, cmap="viridis", xlabel=None, ylabel=None):
     """
     # Validate input type
     if not isinstance(data, (pd.DataFrame, np.ndarray)):
-        raise TypeError("Input data must be a pandas DataFrame or a NumPy array.")
+        raise TypeError("Input data must be a pandas DataFrame or a numpy array.")
     
     # Handle empty data
     if isinstance(data, pd.DataFrame) and data.empty:

--- a/tests/test_plot_heatmap.py
+++ b/tests/test_plot_heatmap.py
@@ -168,3 +168,24 @@ def test_plot_heatmap_custom_labels(rng):
     assert ax.get_xlabel() == "Custom X", "The x-axis label should match the input."
     assert ax.get_ylabel() == "Custom Y", "The y-axis label should match the input."
     plt.close(fig)  # Clean up the figure
+
+# Test for Valid NumPy Array Input
+def test_plot_heatmap_valid_numpy_array():
+    """
+    Test if plot_heatmap works with a valid NumPy array.
+    Ensures that numeric NumPy arrays are accepted as input.
+    """
+    arr = np.random.rand(5, 5)  # Generate a random numeric NumPy array
+    fig, ax = plot_heatmap(arr, title="Valid NumPy Array Test")  # Generate heatmap
+    assert fig is not None, "The heatmap should render for a valid NumPy array."
+    plt.close(fig)  # Clean up the figure
+
+# Test for Non-Numeric NumPy Array
+def test_plot_heatmap_invalid_numpy_array():
+    """
+    Test if plot_heatmap raises a TypeError for non-numeric NumPy arrays.
+    Ensures that only numeric data is accepted in NumPy arrays.
+    """
+    arr = np.array([["a", "b"], ["c", "d"]])  # Non-numeric NumPy array
+    with pytest.raises(TypeError, match="NumPy array must contain numeric data."):
+        plot_heatmap(arr)


### PR DESCRIPTION
This PR addresses TA feedback regarding the missing test coverage for NumPy array input validation in plot_heatmap. Previously, the function allowed NumPy arrays but lacked explicit test cases to verify this behavior.